### PR TITLE
updated: the negative prompt for video styles for stick figure, WW2, …

### DIFF
--- a/src/styles/history.ts
+++ b/src/styles/history.ts
@@ -23,7 +23,7 @@ export const historyStyle: VideoStyle = {
 
   // === Image Generation ===
   imageStyle: "watercolor painting, soft layered washes, gentle color blending, subtle texture of paper, airy natural lighting, muted and harmonious colors, loose and flowing brushstrokes, delicate and artistic finish",
-  negativePrompt: "photorealistic, photograph, 3d render, digital art, vector, cartoon, anime, cel shaded, ink, pencil sketch, blurry, low quality, watermark, text, signature, bad anatomy, deformed, disfigured, extra limbs, missing fingers, ugly face, airbrushed, heavy impasto, thick paint, rough texture",
+  negativePrompt: "photograph, 3d, vector, oil painting, acrylic, impasto, thick paint, strong outlines, neon colors, watermark, text, deformed, ugly, disfigured",
 
   // === Segmentation ===
   segmentationType: "sentence",

--- a/src/styles/stickfigure.ts
+++ b/src/styles/stickfigure.ts
@@ -22,7 +22,7 @@ export const stickfigureStyle: VideoStyle = {
 
     // === Image Generation ===
     imageStyle: "simple stick figure style, black lines on white background, minimal detail, focus on expression and pose, 2D flat",
-    negativePrompt: "realistic, photorealistic, 3d, detailed, complex, colorful, shading, gradient, shadow, texture, photograph",
+    negativePrompt: "3d render, realistic, color, shading, texture, watermark, text",
 
     // === Segmentation ===
     segmentationType: "sentence",

--- a/src/styles/ww2.ts
+++ b/src/styles/ww2.ts
@@ -22,7 +22,7 @@ export const ww2Style: VideoStyle = {
 
   // === Image Generation ===
   imageStyle: "black-and-white WWII documentary style, historical photojournalism, archival war footage look, dramatic high contrast, period-accurate 1940s military equipment and uniforms, authentic atmospheric lighting, professional composition, subtle film grain, realistic details, clear and sharp focus",
-  negativePrompt: "color, vibrant, modern, contemporary, digital, cartoon, anime, painting, illustration, low quality, blurry, watermark, text, signature, bad anatomy, deformed, unrealistic, fantasy, sci-fi, futuristic",
+  negativePrompt: "color, modern, futuristic, anachronistic, illustration, cgi, makeup, watermark, text, deformed, bad anatomy, mutated, disfigured, amputation, malformed",
 
   // === Segmentation ===
   segmentationType: "wordCount",


### PR DESCRIPTION
…and history themes.

## Summary by Sourcery

Adjust negative prompt configurations for several video styles to better align image generation with each theme.

Enhancements:
- Retune the history video style negative prompt to more precisely exclude non-watercolor and unwanted rendering characteristics.
- Refine the stick figure video style negative prompt to avoid detailed, textured, or watermarked outputs.
- Update the WWII video style negative prompt to better filter out modern, fantastical, or anatomically distorted imagery.