### PR TITLE
feat: add SQLite cache, vertical shorts, and graceful shutdown

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -274,6 +274,22 @@ You can override style defaults with command-line flags:
 #history --no-box       # Just change text color
 ```
 
+**Vertical video** (for social media shorts - 9:16 aspect ratio)
+
+> **Note:** `--short` refers to vertical video format (1080x1920), NOT video duration. The output is a tall/portrait video, not a shortened clip.
+
+```
+#history --short        # Create vertical (portrait) video
+#ww2 --short            # Any style works with --short
+```
+
+When using `--short`:
+- Resolution changes from 1920×1080 (horizontal) to 1080×1920 (vertical)
+- Pan effect switches from vertical (up/down) to horizontal (left/right)
+- Font size automatically reduces for narrow screen (52px instead of 72px)
+- Fewer words per caption (2-4 instead of 5-8)
+- Images always zoom to fit (no black bars)
+
 ### Combining Options
 
 You can use multiple options together:
@@ -284,6 +300,10 @@ You can use multiple options together:
 
 ```
 /url https://example.com/audio.mp3 #history --no-pan --highlight=red
+```
+
+```
+#stickfigure --short --karaoke     # Vertical video with karaoke captions
 ```
 
 ---

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,16 @@ services:
     env_file:
       - .env
 
+    # Persist tmp directory across container restarts
+    # This preserves:
+    # - SQLite cache database (tmp/cache.sqlite)
+    # - Downloaded audio files (tmp/audio/)
+    # - Generated images (tmp/images/)
+    # - Rendered videos (tmp/video/)
+    volumes:
+      - v2v-tmp:/app/tmp
+
+# Named volume for persistence
+volumes:
+  v2v-tmp:
+    driver: local

--- a/src/bot.ts
+++ b/src/bot.ts
@@ -94,7 +94,7 @@ async function handleStartCommand(ctx: Context): Promise<void> {
     "🎨 Style Selection:\n" +
     `   • Available: ${availableStyles}\n` +
     "   • Use #style in caption (e.g., #ww2)\n" +
-    "   • Options: --pan, --no-pan, --karaoke, --no-karaoke\n\n" +
+    "   • Options: --pan, --no-pan, --karaoke, --no-karaoke, --short\n\n" +
     "📝 Commands:\n" +
     "   • /upload - Upload audio via Telegram (max 20MB)\n" +
     "   • /url - Provide a presigned URL for large files\n" +
@@ -530,7 +530,8 @@ async function processJob(job: Job, ctx: Context): Promise<void> {
 }
 
 /**
- * Start the bot
+ * Start the bot with graceful error handling
+ * Handles 409 Conflict errors when another bot instance starts
  */
 export async function startBot(): Promise<void> {
   logger.log("Bot", "Initializing bot...");
@@ -542,13 +543,67 @@ export async function startBot(): Promise<void> {
 
   logger.log("Bot", "Starting Telegram bot...");
 
-  // Enable graceful stop
-  process.once("SIGINT", () => bot.stop("SIGINT"));
-  process.once("SIGTERM", () => bot.stop("SIGTERM"));
+  // Graceful shutdown handler
+  const gracefulShutdown = async (reason: string) => {
+    logger.log("Bot", `Received ${reason}, initiating graceful shutdown...`);
 
-  await bot.launch();
+    // Check if there's an active job
+    if (jobQueue.hasActiveJob()) {
+      logger.log("Bot", "Active job detected, waiting for completion...");
+      await jobQueue.waitForCurrentJob();
+    }
 
-  logger.success("Bot", "Bot is running! Send /start to begin.");
-  logger.log("Bot", "Listening for voice and audio messages...");
+    bot.stop(reason);
+    logger.log("Bot", "Bot stopped gracefully");
+  };
+
+  // Enable graceful stop on signals
+  process.once("SIGINT", () => gracefulShutdown("SIGINT"));
+  process.once("SIGTERM", () => gracefulShutdown("SIGTERM"));
+
+  try {
+    await bot.launch();
+    logger.success("Bot", "Bot is running! Send /start to begin.");
+    logger.log("Bot", "Listening for voice and audio messages...");
+  } catch (error) {
+    // Handle 409 Conflict error specifically
+    if (error instanceof Error && error.message.includes("409")) {
+      logger.error("Bot", "Another bot instance is already running!");
+      logger.log("Bot", "If you want to run locally, stop the other instance first.");
+
+      // Check if there's work in progress (though unlikely at startup)
+      if (jobQueue.hasActiveJob()) {
+        logger.log("Bot", "Waiting for any active jobs to complete...");
+        await jobQueue.waitForCurrentJob();
+      }
+
+      // Exit with code 1 but don't throw - prevents ugly stack trace
+      process.exit(1);
+    }
+
+    // Re-throw other errors
+    throw error;
+  }
+
+  // Set up error handler for runtime 409 errors (when another instance starts later)
+  bot.catch(async (err: unknown) => {
+    const errorMessage = err instanceof Error ? err.message : String(err);
+
+    if (errorMessage.includes("409") || errorMessage.includes("Conflict")) {
+      logger.warn("Bot", "Bot connection terminated by another instance");
+
+      // Wait for any active job to complete
+      if (jobQueue.hasActiveJob()) {
+        logger.log("Bot", "Waiting for current job to finish before exiting...");
+        await jobQueue.waitForCurrentJob();
+      }
+
+      logger.log("Bot", "Shutting down gracefully due to conflict");
+      process.exit(0); // Exit cleanly
+    } else {
+      // Log other errors normally
+      logger.error("Bot", "Unhandled bot error", err);
+    }
+  });
 }
 

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -80,6 +80,15 @@ export const TMP_AUDIO_DIR = "tmp/audio";
 export const TMP_IMAGES_DIR = "tmp/images";
 export const TMP_VIDEO_DIR = "tmp/video";
 
+// SQLite Cache Database Path
+export const CACHE_DB_PATH = process.env.CACHE_DB_PATH || "tmp/cache.sqlite";
+
+// Video Dimensions
+export const VIDEO_WIDTH_HORIZONTAL = 1920;
+export const VIDEO_HEIGHT_HORIZONTAL = 1080;
+export const VIDEO_WIDTH_VERTICAL = 1080;
+export const VIDEO_HEIGHT_VERTICAL = 1920;
+
 // Processing Configuration
 export const POLL_INTERVAL_MS = 2200; // 2.2 seconds between poll attempts
 export const MAX_POLL_ATTEMPTS = 60; // 10 minutes max
@@ -99,8 +108,9 @@ export const TOGETHER_API_KEY = process.env.TOGETHER_API_KEY || "";
 
 // Together AI Configuration
 export const TOGETHER_API_URL = "https://api.together.xyz/v1/images/generations";
+//black-forest-labs/FLUX.2-dev (best image generation -- better than FLUX.1-schnell-Free)
 export const TOGETHER_MODEL = "black-forest-labs/FLUX.1-schnell-Free";
-export const TOGETHER_RATE_LIMIT_PER_MIN = 6; // FLUX.1 [schnell] Free has 6 img/min limit
+export const TOGETHER_RATE_LIMIT_PER_MIN = 6; // black-forest-labs/FLUX.1-schnell-Free - Free has 6 img/min limit
 export const TOGETHER_MIN_DELAY_MS = 60000 / TOGETHER_RATE_LIMIT_PER_MIN; // ~10000ms minimum between requests
 
 // Debug Mode

--- a/src/services/cache.ts
+++ b/src/services/cache.ts
@@ -1,0 +1,377 @@
+/**
+ * SQLite Cache Service for workflow step caching
+ * Uses Bun's built-in SQLite support to avoid redundant API calls
+ * 
+ * Cached Steps:
+ * 1. AssemblyAI Upload URL
+ * 2. Transcription (transcript ID, words, duration)
+ * 3. Segmentation (segments, formatted transcript)
+ * 4. LLM Image Queries
+ * 5. Downloaded/Generated Images
+ * 
+ * NOT Cached: Video generation (always regenerates with FFmpeg)
+ */
+
+import { Database } from "bun:sqlite";
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+import { CACHE_DB_PATH } from "../constants.ts";
+import type { AssemblyAIWord, TranscriptSegment, ImageSearchQuery, DownloadedImage } from "../types.ts";
+import * as logger from "../logger.ts";
+
+/**
+ * Cache entry structure matching database schema
+ */
+export interface AudioCacheEntry {
+    id: number;
+    audio_hash: string;
+    audio_filename: string;
+    audio_path: string | null;
+
+    // Step 1: Upload
+    upload_url: string | null;
+
+    // Step 2: Transcription
+    transcript_id: string | null;
+    transcript_status: string | null;
+    transcript_words: string | null;
+    audio_duration: number | null;
+
+    // Step 3: Segmentation
+    segments: string | null;
+    formatted_transcript: string | null;
+    style_id: string | null;
+
+    // Step 4: LLM Queries
+    image_queries: string | null;
+
+    // Step 5: Images
+    downloaded_images: string | null;
+
+    // Metadata
+    created_at: number;
+    updated_at: number;
+}
+
+/**
+ * Partial cache data for updates
+ */
+export interface CacheUpdate {
+    audio_filename?: string;
+    audio_path?: string;
+    upload_url?: string;
+    transcript_id?: string;
+    transcript_status?: string;
+    transcript_words?: string;
+    audio_duration?: number;
+    segments?: string;
+    formatted_transcript?: string;
+    style_id?: string;
+    image_queries?: string;
+    downloaded_images?: string;
+}
+
+// Singleton database instance
+let db: Database | null = null;
+
+/**
+ * Initialize the SQLite database and create tables if needed
+ */
+export function initDatabase(): void {
+    if (db) return;
+
+    // Ensure directory exists
+    const dbDir = dirname(CACHE_DB_PATH);
+    if (!existsSync(dbDir)) {
+        Bun.spawnSync(["mkdir", "-p", dbDir]);
+    }
+
+    db = new Database(CACHE_DB_PATH);
+
+    // Create table if not exists
+    db.run(`
+    CREATE TABLE IF NOT EXISTS audio_cache (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      audio_hash TEXT UNIQUE NOT NULL,
+      audio_filename TEXT NOT NULL,
+      audio_path TEXT,
+      
+      upload_url TEXT,
+      
+      transcript_id TEXT,
+      transcript_status TEXT,
+      transcript_words TEXT,
+      audio_duration REAL,
+      
+      segments TEXT,
+      formatted_transcript TEXT,
+      style_id TEXT,
+      
+      image_queries TEXT,
+      
+      downloaded_images TEXT,
+      
+      created_at INTEGER DEFAULT (strftime('%s', 'now')),
+      updated_at INTEGER DEFAULT (strftime('%s', 'now'))
+    )
+  `);
+
+    // Create index for fast lookups
+    db.run(`CREATE INDEX IF NOT EXISTS idx_audio_hash ON audio_cache(audio_hash)`);
+
+    logger.debug("Cache", `Database initialized at ${CACHE_DB_PATH}`);
+}
+
+/**
+ * Get the database instance, initializing if needed
+ */
+function getDb(): Database {
+    if (!db) {
+        initDatabase();
+    }
+    return db!;
+}
+
+/**
+ * Generate MD5 hash of an audio file for identification
+ * @param filePath - Path to the audio file
+ * @returns MD5 hash string
+ */
+export async function hashAudioFile(filePath: string): Promise<string> {
+    const fileBuffer = await readFile(filePath);
+    const hash = createHash("md5").update(fileBuffer).digest("hex");
+    logger.debug("Cache", `Audio hash: ${hash} (${filePath})`);
+    return hash;
+}
+
+/**
+ * Get cache entry by audio hash
+ * @param audioHash - MD5 hash of the audio file
+ * @returns Cache entry or null if not found
+ */
+export function getCache(audioHash: string): AudioCacheEntry | null {
+    const database = getDb();
+    const stmt = database.prepare("SELECT * FROM audio_cache WHERE audio_hash = ?");
+    const result = stmt.get(audioHash) as AudioCacheEntry | null;
+
+    if (result) {
+        logger.debug("Cache", `Found cache entry for hash ${audioHash.substring(0, 8)}...`);
+    }
+
+    return result;
+}
+
+/**
+ * Create or update cache entry
+ * @param audioHash - MD5 hash of the audio file
+ * @param data - Partial cache data to update
+ */
+export function updateCache(audioHash: string, data: CacheUpdate): void {
+    const database = getDb();
+    const existing = getCache(audioHash);
+
+    if (existing) {
+        // Build UPDATE query dynamically
+        const fields: string[] = [];
+        const values: (string | number | null)[] = [];
+
+        for (const [key, value] of Object.entries(data)) {
+            if (value !== undefined) {
+                fields.push(`${key} = ?`);
+                values.push(value);
+            }
+        }
+
+        if (fields.length > 0) {
+            fields.push("updated_at = strftime('%s', 'now')");
+            values.push(audioHash);
+
+            const sql = `UPDATE audio_cache SET ${fields.join(", ")} WHERE audio_hash = ?`;
+            const stmt = database.prepare(sql);
+            stmt.run(...values);
+            logger.debug("Cache", `Updated cache for hash ${audioHash.substring(0, 8)}...`);
+        }
+    } else {
+        // INSERT new entry
+        const filename = data.audio_filename || "unknown";
+        const insertStmt = database.prepare(
+            `INSERT INTO audio_cache (audio_hash, audio_filename) VALUES (?, ?)`
+        );
+        insertStmt.run(audioHash, filename);
+
+        // Now update with remaining data
+        if (Object.keys(data).length > 1 || !data.audio_filename) {
+            updateCache(audioHash, data);
+        }
+
+        logger.debug("Cache", `Created cache entry for hash ${audioHash.substring(0, 8)}...`);
+    }
+}
+
+/**
+ * Delete a cache entry by audio hash
+ * @param audioHash - MD5 hash of the audio file
+ */
+export function deleteCache(audioHash: string): void {
+    const database = getDb();
+    const stmt = database.prepare("DELETE FROM audio_cache WHERE audio_hash = ?");
+    stmt.run(audioHash);
+    logger.debug("Cache", `Deleted cache for hash ${audioHash.substring(0, 8)}...`);
+}
+
+/**
+ * Clear all cache entries from the database
+ * @returns Object with count of deleted entries
+ */
+export function clearAllCache(): { count: number } {
+    const database = getDb();
+
+    // Get count before deletion
+    const countResult = database.prepare("SELECT COUNT(*) as count FROM audio_cache").get() as { count: number };
+    const count = countResult?.count || 0;
+
+    // Delete all entries
+    database.run("DELETE FROM audio_cache");
+
+    logger.success("Cache", `Cleared ${count} cache entries from database`);
+
+    return { count };
+}
+
+// ============================================================
+// Step-Specific Cache Helpers
+// ============================================================
+
+/**
+ * Get cached upload URL
+ * @param audioHash - Audio file hash
+ * @returns Upload URL or null
+ */
+export function getCachedUploadUrl(audioHash: string): string | null {
+    const cache = getCache(audioHash);
+    return cache?.upload_url || null;
+}
+
+/**
+ * Get cached transcript data
+ * @param audioHash - Audio file hash
+ * @returns Transcript data or null
+ */
+export function getCachedTranscript(audioHash: string): {
+    transcriptId: string;
+    words: AssemblyAIWord[];
+    audioDuration: number | null;
+} | null {
+    const cache = getCache(audioHash);
+
+    if (cache?.transcript_id && cache?.transcript_words) {
+        try {
+            const words = JSON.parse(cache.transcript_words) as AssemblyAIWord[];
+            return {
+                transcriptId: cache.transcript_id,
+                words,
+                audioDuration: cache.audio_duration,
+            };
+        } catch {
+            logger.warn("Cache", "Failed to parse cached transcript words");
+            return null;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Get cached segments (style-specific)
+ * @param audioHash - Audio file hash
+ * @param styleId - Current style ID
+ * @returns Segments data or null (returns null if style changed)
+ */
+export function getCachedSegments(audioHash: string, styleId: string): {
+    segments: TranscriptSegment[];
+    formattedTranscript: string;
+} | null {
+    const cache = getCache(audioHash);
+
+    // Only use cache if same style was used
+    if (cache?.segments && cache?.formatted_transcript && cache?.style_id === styleId) {
+        try {
+            const segments = JSON.parse(cache.segments) as TranscriptSegment[];
+            return {
+                segments,
+                formattedTranscript: cache.formatted_transcript,
+            };
+        } catch {
+            logger.warn("Cache", "Failed to parse cached segments");
+            return null;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Get cached image queries (style-specific)
+ * @param audioHash - Audio file hash
+ * @param styleId - Current style ID
+ * @returns Image queries or null
+ */
+export function getCachedImageQueries(audioHash: string, styleId: string): ImageSearchQuery[] | null {
+    const cache = getCache(audioHash);
+
+    // Only use cache if same style was used
+    if (cache?.image_queries && cache?.style_id === styleId) {
+        try {
+            return JSON.parse(cache.image_queries) as ImageSearchQuery[];
+        } catch {
+            logger.warn("Cache", "Failed to parse cached image queries");
+            return null;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Get cached downloaded images (with file existence verification)
+ * @param audioHash - Audio file hash
+ * @returns Downloaded images or null (returns null if any file is missing)
+ */
+export function getCachedImages(audioHash: string): DownloadedImage[] | null {
+    const cache = getCache(audioHash);
+
+    if (cache?.downloaded_images) {
+        try {
+            const images = JSON.parse(cache.downloaded_images) as DownloadedImage[];
+
+            // Verify all image files still exist
+            for (const image of images) {
+                if (!existsSync(image.filePath)) {
+                    logger.warn("Cache", `Cached image file missing: ${image.filePath}`);
+                    return null;
+                }
+            }
+
+            return images;
+        } catch {
+            logger.warn("Cache", "Failed to parse cached images");
+            return null;
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Close the database connection
+ */
+export function closeDatabase(): void {
+    if (db) {
+        db.close();
+        db = null;
+        logger.debug("Cache", "Database connection closed");
+    }
+}

--- a/src/services/captions.ts
+++ b/src/services/captions.ts
@@ -204,18 +204,25 @@ export async function generateAssSubtitles(
   const highlightBackColor = highlightStyle.useBox ? highlightStyle.color : captionStyle.backgroundColor;
   const highlightOutlineWidth = highlightStyle.useBox ? 6 : captionStyle.outlineWidth;
 
+  // Get video dimensions based on orientation
+  const isVertical = style.orientation === "vertical";
+  const playResX = isVertical ? 1080 : 1920;
+  const playResY = isVertical ? 1920 : 1080;
+  // Adjust margin for vertical videos (position captions higher on the taller screen)
+  const marginV = isVertical ? 550 : 130;
+
   const assHeader = `[Script Info]
 Title: Word-by-Word Highlighted Captions
 ScriptType: v4.00+
 WrapStyle: 0
-PlayResX: 1920
-PlayResY: 1080
+PlayResX: ${playResX}
+PlayResY: ${playResY}
 ScaledBorderAndShadow: yes
 
 [V4+ Styles]
 Format: Name, Fontname, Fontsize, PrimaryColour, SecondaryColour, OutlineColour, BackColour, Bold, Italic, Underline, StrikeOut, ScaleX, ScaleY, Spacing, Angle, BorderStyle, Outline, Shadow, Alignment, MarginL, MarginR, MarginV, Encoding
-Style: Default,${captionStyle.fontName},${captionStyle.fontSize},${captionStyle.primaryColor},&H000000FF,${captionStyle.outlineColor},${captionStyle.backgroundColor},-1,0,0,0,100,100,0,0,${defaultBorderStyle},${captionStyle.outlineWidth},${captionStyle.shadowDepth},2,10,10,130,1
-Style: Highlight,${captionStyle.fontName},${captionStyle.fontSize},${highlightPrimaryColor},&H000000FF,${highlightOutlineColor},${highlightBackColor},-1,0,0,0,100,100,0,0,${highlightBorderStyle},${highlightOutlineWidth},${captionStyle.shadowDepth},2,10,10,130,1
+Style: Default,${captionStyle.fontName},${captionStyle.fontSize},${captionStyle.primaryColor},&H000000FF,${captionStyle.outlineColor},${captionStyle.backgroundColor},-1,0,0,0,100,100,0,0,${defaultBorderStyle},${captionStyle.outlineWidth},${captionStyle.shadowDepth},2,10,10,${marginV},1
+Style: Highlight,${captionStyle.fontName},${captionStyle.fontSize},${highlightPrimaryColor},&H000000FF,${highlightOutlineColor},${highlightBackColor},-1,0,0,0,100,100,0,0,${highlightBorderStyle},${highlightOutlineWidth},${captionStyle.shadowDepth},2,10,10,${marginV},1
 
 [Events]
 Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text

--- a/src/services/cleanup.ts
+++ b/src/services/cleanup.ts
@@ -1,6 +1,6 @@
 /**
- * Cleanup service for temporary files
- * Handles deletion of temporary files after successful workflow completion
+ * Cleanup service for temporary files and cache database
+ * Handles deletion of temporary files and cache entries after successful workflow completion
  */
 
 import { readdir, unlink, stat } from "node:fs/promises";
@@ -8,6 +8,7 @@ import { join } from "node:path";
 import * as logger from "../logger.ts";
 import { TMP_AUDIO_DIR, TMP_IMAGES_DIR, TMP_VIDEO_DIR } from "../constants.ts";
 import type { CleanupResult } from "../types.ts";
+import { clearAllCache } from "./cache.ts";
 
 /**
  * Clean up all temporary files after successful workflow completion
@@ -47,9 +48,13 @@ export async function cleanupTempFiles(
   failedFiles.push(...videoResult.failed);
   totalSize += videoResult.size;
 
+  // Clear cache database
+  const cacheResult = clearAllCache();
+
   // Log summary
   const totalSizeMB = (totalSize / 1024 / 1024).toFixed(2);
   logger.success("Cleanup", `Deleted ${deletedFiles.length} files (${totalSizeMB} MB freed)`);
+  logger.success("Cleanup", `Cleared ${cacheResult.count} entries from cache database`);
 
   if (failedFiles.length > 0) {
     logger.warn("Cleanup", `Failed to delete ${failedFiles.length} files`);

--- a/src/services/images.ts
+++ b/src/services/images.ts
@@ -308,9 +308,9 @@ async function generateTogetherAIImage(
           n: 1,
           width: 1440,
           height: 1104,
-          steps: 4,
-          negative_prompt: style.negativePrompt,
-          guidance_scale: 20,
+          // steps: 20,
+          // negative_prompt: style.negativePrompt,
+          // guidance_scale: 20,
           disable_safety_checker: false,
         }),
       });

--- a/src/services/queue.ts
+++ b/src/services/queue.ts
@@ -73,6 +73,40 @@ class JobQueueService {
   }
 
   /**
+   * Check if a job is currently being processed
+   * @returns True if a job is in progress
+   */
+  hasActiveJob(): boolean {
+    return this.isProcessing;
+  }
+
+  /**
+   * Wait for the current job to finish (if any)
+   * Used for graceful shutdown
+   * @param maxWaitMs - Maximum time to wait in milliseconds (default: 5 minutes)
+   * @returns Promise that resolves when current job is done or timeout
+   */
+  async waitForCurrentJob(maxWaitMs: number = 300000): Promise<void> {
+    if (!this.isProcessing) {
+      return;
+    }
+
+    logger.log("Queue", "Waiting for current job to finish before shutdown...");
+    const startTime = Date.now();
+    const pollInterval = 1000; // Check every second
+
+    while (this.isProcessing && (Date.now() - startTime) < maxWaitMs) {
+      await new Promise(resolve => setTimeout(resolve, pollInterval));
+    }
+
+    if (this.isProcessing) {
+      logger.warn("Queue", "Timeout waiting for job to finish, proceeding with shutdown");
+    } else {
+      logger.success("Queue", "Current job finished, proceeding with shutdown");
+    }
+  }
+
+  /**
    * Add a file-based job to the queue
    * @param ctx - Telegram context
    * @param fileId - Telegram file ID

--- a/src/services/video.ts
+++ b/src/services/video.ts
@@ -41,7 +41,8 @@ export async function generateVideo(
   logger.debug("Video", `Style: ${style.name} (${style.id})`);
 
   if (panEffect) {
-    logger.log("Video", "🎬 Pan effect enabled - applying subtle vertical motion to images");
+    const panDirection = style.orientation === "vertical" ? "horizontal" : "vertical";
+    logger.log("Video", `🎬 Pan effect enabled - applying ${panDirection} motion to images`);
   } else {
     logger.log("Video", "📷 Pan effect disabled - using static images");
   }
@@ -71,7 +72,7 @@ export async function generateVideo(
     await renderVideoInChunks(sortedImages, audioFilePath, outputPath, words, segments, style);
   } else {
     logger.step("Video", `Using single-pass rendering (${sortedImages.length} images)`);
-    const { filterComplex } = createFilterComplex(sortedImages, panEffect, style.zoomToFit);
+    const { filterComplex } = createFilterComplex(sortedImages, panEffect, style.zoomToFit, style.orientation);
     let assFilePath: string | undefined;
     if (captionsEnabled) {
       const captionResult = await generateCaptions(segments, words, style);
@@ -276,7 +277,7 @@ async function renderVideoInChunks(
     chunkPaths.push(chunkPath);
 
     // Create filter complex for this chunk
-    const { filterComplex } = createFilterComplex(chunk, panEffect, style.zoomToFit);
+    const { filterComplex } = createFilterComplex(chunk, panEffect, style.zoomToFit, style.orientation);
 
     let chunkAssPath: string | undefined;
     if (captionsEnabled) {

--- a/src/services/workflow.ts
+++ b/src/services/workflow.ts
@@ -1,6 +1,7 @@
 /**
  * Workflow service for orchestrating the audio-to-video process
  * Supports configurable video styles via style system
+ * Uses SQLite cache to skip completed steps and avoid redundant API calls
  */
 
 import {
@@ -9,7 +10,7 @@ import {
     type Context,
 } from "../utils/telegram.ts";
 import { TMP_AUDIO_DIR, MINIO_ENABLED } from "../constants.ts";
-import type { WorkflowResult } from "../types.ts";
+import type { WorkflowResult, AssemblyAIWord, TranscriptSegment, ImageSearchQuery, DownloadedImage } from "../types.ts";
 import type { ResolvedStyle } from "../styles/types.ts";
 import { getDefaultStyle, resolveStyle } from "../styles/index.ts";
 import { transcribeAudio } from "./assemblyai.ts";
@@ -22,6 +23,14 @@ import {
 import { generateVideo, validateVideoInputs } from "./video.ts";
 import { uploadVideoToMinIO } from "./minio.ts";
 import { ProgressTracker } from "./progress.ts";
+import {
+    hashAudioFile,
+    updateCache,
+    getCachedTranscript,
+    getCachedSegments,
+    getCachedImageQueries,
+    getCachedImages,
+} from "./cache.ts";
 import * as logger from "../logger.ts";
 import path from "node:path";
 
@@ -116,6 +125,8 @@ export class WorkflowService {
     /**
      * Run the core workflow logic (transcription -> images -> video)
      * This is shared between Telegram file and URL workflows
+     * Uses SQLite cache to skip steps that have already been completed
+     * 
      * @param audioFilePath - Path to the audio file
      * @param progress - Progress tracker for status updates
      * @param style - Resolved style configuration
@@ -127,33 +138,118 @@ export class WorkflowService {
     ): Promise<WorkflowResult> {
         logger.step("Workflow", `Using style: ${style.name} (${style.id})`);
         logger.debug("Workflow", `Segmentation: ${style.segmentationType}, Pan: ${style.panEffect}, Captions: ${style.captionsEnabled}`);
-        // Step 2: Transcribe audio with AssemblyAI
+
+        // =============================================================
+        // CACHE INITIALIZATION
+        // =============================================================
         await progress.update({
-            step: "Transcription",
-            message: "Transcribing audio with AssemblyAI...\nThis may take a few minutes.",
+            step: "Initializing",
+            message: "Checking cache and preparing workflow...",
         });
-        const transcript = await transcribeAudio(audioFilePath);
-        logger.step("Workflow", "Transcription completed", `${transcript.text.substring(0, 100)}...`);
+
+        // Hash the audio file for cache lookup
+        const audioHash = await hashAudioFile(audioFilePath);
+        const filename = path.basename(audioFilePath);
+
+        // Initialize cache entry with filename
+        updateCache(audioHash, {
+            audio_filename: filename,
+            audio_path: audioFilePath
+        });
+
+        // =============================================================
+        // STEP 1-2: TRANSCRIPTION (Check cache first)
+        // =============================================================
+        let transcriptWords: AssemblyAIWord[];
+        let audioDuration: number | null;
+
+        const cachedTranscript = getCachedTranscript(audioHash);
+
+        if (cachedTranscript) {
+            logger.log("Workflow", "📦 Using cached transcript (skipping AssemblyAI API call)");
+            transcriptWords = cachedTranscript.words;
+            audioDuration = cachedTranscript.audioDuration;
+        } else {
+            await progress.update({
+                step: "Transcription",
+                message: "Transcribing audio with AssemblyAI...\\nThis may take a few minutes.",
+            });
+
+            const transcript = await transcribeAudio(audioFilePath);
+            transcriptWords = transcript.words;
+            audioDuration = transcript.audio_duration;
+
+            // Save to cache
+            updateCache(audioHash, {
+                transcript_id: transcript.id,
+                transcript_words: JSON.stringify(transcript.words),
+                audio_duration: transcript.audio_duration ?? undefined,
+            });
+
+            logger.step("Workflow", "Transcription completed and cached");
+        }
 
         // Validate transcript data
-        validateTranscriptData(transcript.words);
+        validateTranscriptData(transcriptWords);
 
-        // Step 3: Process transcript into segments (using style-specific segmentation)
-        await progress.update({
-            step: "Processing Transcript",
-            message: `Segmenting transcript (${style.segmentationType} mode)...`,
-        });
-        const { segments, formattedTranscript } = processTranscript(transcript.words, transcript.audio_duration, style);
-        logger.step("Workflow", `Created ${segments.length} segments`);
+        // =============================================================
+        // STEP 3: SEGMENTATION (Check cache first, style-specific)
+        // =============================================================
+        let segments: TranscriptSegment[];
+        let formattedTranscript: string;
 
-        // Step 4: Generate image search queries with LLM (using style-specific context)
-        await progress.update({
-            step: "Generating Image Queries",
-            message: "Using AI to generate visual scene descriptions...",
-        });
-        const imageQueries = await generateImageQueries(formattedTranscript, style);
-        validateImageQueries(imageQueries);
-        logger.step("Workflow", `Generated ${imageQueries.length} image queries`);
+        const cachedSegments = getCachedSegments(audioHash, style.id);
+
+        if (cachedSegments) {
+            logger.log("Workflow", "📦 Using cached segments (same style)");
+            segments = cachedSegments.segments;
+            formattedTranscript = cachedSegments.formattedTranscript;
+        } else {
+            await progress.update({
+                step: "Processing Transcript",
+                message: `Segmenting transcript (${style.segmentationType} mode)...`,
+            });
+
+            const result = processTranscript(transcriptWords, audioDuration, style);
+            segments = result.segments;
+            formattedTranscript = result.formattedTranscript;
+
+            // Save to cache (include style_id for style-specific caching)
+            updateCache(audioHash, {
+                segments: JSON.stringify(segments),
+                formatted_transcript: formattedTranscript,
+                style_id: style.id,
+            });
+
+            logger.step("Workflow", `Created ${segments.length} segments and cached`);
+        }
+
+        // =============================================================
+        // STEP 4: LLM IMAGE QUERIES (Check cache first, style-specific)
+        // =============================================================
+        let imageQueries: ImageSearchQuery[];
+
+        const cachedQueries = getCachedImageQueries(audioHash, style.id);
+
+        if (cachedQueries) {
+            logger.log("Workflow", "📦 Using cached image queries (skipping LLM API call)");
+            imageQueries = cachedQueries;
+        } else {
+            await progress.update({
+                step: "Generating Image Queries",
+                message: "Using AI to generate visual scene descriptions...",
+            });
+
+            imageQueries = await generateImageQueries(formattedTranscript, style);
+            validateImageQueries(imageQueries);
+
+            // Save to cache
+            updateCache(audioHash, {
+                image_queries: JSON.stringify(imageQueries),
+            });
+
+            logger.step("Workflow", `Generated ${imageQueries.length} image queries and cached`);
+        }
 
         // Validate that we have exactly one query per segment
         if (imageQueries.length !== segments.length) {
@@ -179,25 +275,45 @@ export class WorkflowService {
             }
         }
 
-        // Step 5: Search and download images (using style-specific prompts)
-        await progress.update({
-            step: "Downloading Images",
-            message: `Searching and downloading ${imageQueries.length} images...`,
-            current: 0,
-            total: imageQueries.length,
-        });
-        const downloadedImages = await downloadImagesForQueries(imageQueries, style);
-        validateDownloadedImages(downloadedImages);
-        logger.step("Workflow", `Downloaded ${downloadedImages.length} images`);
+        // =============================================================
+        // STEP 5: DOWNLOAD/GENERATE IMAGES (Check cache first)
+        // =============================================================
+        let downloadedImages: DownloadedImage[];
 
-        // Step 6: Generate video with FFmpeg (using style-specific effects)
+        const cachedImages = getCachedImages(audioHash);
+
+        if (cachedImages && cachedImages.length === imageQueries.length) {
+            logger.log("Workflow", "📦 Using cached images (all files verified to exist)");
+            downloadedImages = cachedImages;
+        } else {
+            await progress.update({
+                step: "Downloading Images",
+                message: `Searching and downloading ${imageQueries.length} images...`,
+                current: 0,
+                total: imageQueries.length,
+            });
+
+            downloadedImages = await downloadImagesForQueries(imageQueries, style);
+            validateDownloadedImages(downloadedImages);
+
+            // Save to cache
+            updateCache(audioHash, {
+                downloaded_images: JSON.stringify(downloadedImages),
+            });
+
+            logger.step("Workflow", `Downloaded ${downloadedImages.length} images and cached`);
+        }
+
+        // =============================================================
+        // STEP 6: VIDEO GENERATION (Always regenerate, never cached)
+        // =============================================================
         await progress.update({
             step: "Generating Video",
-            message: "Creating video with FFmpeg...\nThis may take a few minutes for long videos.",
+            message: "Creating video with FFmpeg...\\nThis may take a few minutes for long videos.",
         });
         validateVideoInputs(downloadedImages, audioFilePath);
         const outputFileName = path.parse(audioFilePath).name;
-        const videoResult = await generateVideo(downloadedImages, audioFilePath, transcript.words, segments, outputFileName, style);
+        const videoResult = await generateVideo(downloadedImages, audioFilePath, transcriptWords, segments, outputFileName, style);
         logger.step("Workflow", "Video created", videoResult.videoPath);
 
         const result: WorkflowResult = {
@@ -205,7 +321,7 @@ export class WorkflowService {
             duration: videoResult.duration,
         };
 
-        // Step 8: Upload to MinIO (if enabled)
+        // Step 7: Upload to MinIO (if enabled)
         if (MINIO_ENABLED) {
             await progress.update({
                 step: "Uploading to MinIO",

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -68,13 +68,29 @@ export function styleExists(styleId: string): boolean {
  * @returns ResolvedStyle with options applied
  */
 export function resolveStyle(style: VideoStyle, options: StyleOptions = {}): ResolvedStyle {
+  // Determine orientation (default: horizontal)
+  const orientation = options.orientation || "horizontal";
+  const isShorts = orientation === "vertical";
+
   // Create a deep copy of the style to avoid mutation
   const resolved: ResolvedStyle = {
     ...style,
     captionStyle: { ...style.captionStyle },
     highlightStyle: { ...style.highlightStyle },
     appliedOptions: options,
+    orientation,
   };
+
+  // Apply shorts-specific overrides
+  if (isShorts) {
+    // Smaller font size for narrow vertical screen
+    resolved.captionStyle.fontSize = 62;
+    // Fewer words per caption for readability
+    resolved.minWordsPerCaption = 2;
+    resolved.maxWordsPerCaption = 4;
+    // Always zoom to fit for shorts (no black bars)
+    resolved.zoomToFit = true;
+  }
 
   // Apply pan effect override
   if (options.panEffect !== undefined) {
@@ -161,6 +177,11 @@ export function parseStyleFromMessage(text: string): { styleId: string; options:
   // Parse --no-box or --nobox flag
   if (/--no-?box\b/i.test(text)) {
     options.highlightBox = false;
+  }
+
+  // Parse --short or --shorts flag (vertical 9:16 format)
+  if (/--shorts?\b/i.test(text)) {
+    options.orientation = "vertical";
   }
 
   return { styleId, options };

--- a/src/styles/types.ts
+++ b/src/styles/types.ts
@@ -8,6 +8,11 @@
 export type SegmentationType = "sentence" | "wordCount";
 
 /**
+ * Video orientation - horizontal (16:9) or vertical (9:16 shorts)
+ */
+export type VideoOrientation = "horizontal" | "vertical";
+
+/**
  * Caption style configuration - colors, fonts, and visual settings
  * ASS format uses BGR color order: &HAABBGGRR
  */
@@ -90,7 +95,7 @@ export interface VideoStyle {
 
 /**
  * Runtime options that can override style defaults
- * These are parsed from Telegram commands (e.g., --pan, --karaoke)
+ * These are parsed from Telegram commands (e.g., --pan, --karaoke, --short)
  */
 export interface StyleOptions {
   /** Override pan effect setting */
@@ -101,6 +106,8 @@ export interface StyleOptions {
   highlightColor?: string;
   /** Override highlight box setting */
   highlightBox?: boolean;
+  /** Override video orientation (--short sets this to "vertical") */
+  orientation?: VideoOrientation;
 }
 
 /**
@@ -109,6 +116,8 @@ export interface StyleOptions {
 export interface ResolvedStyle extends VideoStyle {
   /** Runtime options that were applied */
   appliedOptions: StyleOptions;
+  /** Video orientation (horizontal or vertical/shorts) */
+  orientation: VideoOrientation;
 }
 
 /**

--- a/src/styles/ww2.ts
+++ b/src/styles/ww2.ts
@@ -22,7 +22,8 @@ export const ww2Style: VideoStyle = {
 
   // === Image Generation ===
   imageStyle: "black-and-white WWII documentary style, historical photojournalism, archival war footage look, dramatic high contrast, period-accurate 1940s military equipment and uniforms, authentic atmospheric lighting, professional composition, subtle film grain, realistic details, clear and sharp focus",
-  negativePrompt: "color, modern, futuristic, anachronistic, illustration, cgi, makeup, watermark, text, deformed, bad anatomy, mutated, disfigured, amputation, malformed",
+  // negativePrompt: "color, modern, futuristic, anachronistic, illustration, cgi, makeup, watermark, text, deformed, bad anatomy, mutated, disfigured, amputation, malformed",
+    negativePrompt: "color, vibrant, modern, contemporary, digital, cartoon, anime, painting, illustration, low quality, blurry, watermark, text, signature, bad anatomy, deformed, unrealistic, fantasy, sci-fi, futuristic",
 
   // === Segmentation ===
   segmentationType: "wordCount",
@@ -50,6 +51,7 @@ export const ww2Style: VideoStyle = {
 
   // === Video Effects ===
   panEffect: false,
+  zoomToFit: true,
 
   // === LLM Context ===
   llmContext: `You are generating image prompts for a World War 2 documentary video.

--- a/src/types.ts
+++ b/src/types.ts
@@ -119,13 +119,15 @@ export interface CleanupResult {
 }
 
 // FFmpeg Types
-export type PanDirection = "up" | "down";
+export type PanDirection = "up" | "down" | "left" | "right";
 
 export interface PanParams {
   enabled: boolean;
   direction: PanDirection;
-  yStart: number; // Starting Y position (pixels)
-  yEnd: number; // Ending Y position (pixels)
+  yStart: number; // Starting Y position (pixels) - for vertical pan
+  yEnd: number; // Ending Y position (pixels) - for vertical pan
+  xStart: number; // Starting X position (pixels) - for horizontal pan
+  xEnd: number; // Ending X position (pixels) - for horizontal pan
 }
 
 // Workflow Types

--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -1,90 +1,150 @@
 /**
  * FFmpeg utility functions for video processing
  * Supports configurable pan effects via style system
+ * Supports both horizontal (16:9) and vertical (9:16 shorts) orientations
  */
 
 import type { DownloadedImage, PanDirection, PanParams } from "../types.ts";
+import type { VideoOrientation } from "../styles/types.ts";
+import {
+    VIDEO_WIDTH_HORIZONTAL,
+    VIDEO_HEIGHT_HORIZONTAL,
+    VIDEO_WIDTH_VERTICAL,
+    VIDEO_HEIGHT_VERTICAL,
+} from "../constants.ts";
 import * as logger from "../logger.ts";
 
 /**
- * Calculate pan parameters based on image aspect ratio and duration
- * @param _duration - Scene duration in seconds (reserved for future speed calculations)
- * @param panEnabled - Whether pan effect is enabled
- * @returns Pan parameters for zoompan filter
+ * Get video dimensions based on orientation
+ * @param orientation - Video orientation (horizontal or vertical)
+ * @returns Object with width and height
  */
-export function calculatePanParams(_duration: number, panEnabled: boolean = true): PanParams {
-    // If pan effect is disabled, return disabled params
-    if (!panEnabled) {
+export function getVideoDimensions(orientation: VideoOrientation): { width: number; height: number } {
+    if (orientation === "vertical") {
+        return { width: VIDEO_WIDTH_VERTICAL, height: VIDEO_HEIGHT_VERTICAL };
+    }
+    return { width: VIDEO_WIDTH_HORIZONTAL, height: VIDEO_HEIGHT_HORIZONTAL };
+}
+
+/**
+ * Calculate pan parameters based on image aspect ratio and orientation
+ * - Horizontal video (16:9): vertical pan (up/down)
+ * - Vertical video (9:16 shorts): horizontal pan (left/right)
+ * - Scenes under 3 seconds: no pan (would look too fast/jarring)
+ * 
+ * @param duration - Scene duration in seconds
+ * @param panEnabled - Whether pan effect is enabled
+ * @param orientation - Video orientation
+ * @returns Pan parameters for crop filter
+ */
+export function calculatePanParams(
+    duration: number,
+    panEnabled: boolean = true,
+    orientation: VideoOrientation = "horizontal"
+): PanParams {
+    // Minimum duration for pan effect (3 seconds)
+    // Panning on shorter segments looks jarring/too fast
+    const MIN_PAN_DURATION = 3;
+
+    // If pan effect is disabled or duration is too short, return disabled params
+    if (!panEnabled || duration < MIN_PAN_DURATION) {
         return {
             enabled: false,
             direction: "down",
             yStart: 0,
             yEnd: 0,
+            xStart: 0,
+            xEnd: 0,
         };
     }
 
-    // Target video dimensions
-    const VIDEO_WIDTH = 1920;
-    const VIDEO_HEIGHT = 1080;
+    const { width: VIDEO_WIDTH, height: VIDEO_HEIGHT } = getVideoDimensions(orientation);
 
-    // AI-generated image dimensions (4:3 aspect ratio)
+    // AI-generated image dimensions (4:3 aspect ratio from FLUX)
     const IMAGE_WIDTH = 1472;
     const IMAGE_HEIGHT = 1104;
 
-    // Calculate scaled dimensions when fitting image to video width
-    // The image will be scaled to fit 1920px width while maintaining aspect ratio
-    const scaledHeight = (IMAGE_HEIGHT * VIDEO_WIDTH) / IMAGE_WIDTH; // = 1440px
+    if (orientation === "vertical") {
+        // VERTICAL (SHORTS): Horizontal pan (left/right)
+        // Scale image to fit height, then pan horizontally
+        const scaledWidth = (IMAGE_WIDTH * VIDEO_HEIGHT) / IMAGE_HEIGHT;
+        const totalHeadroom = scaledWidth - VIDEO_WIDTH;
+        const usableHeadroom = totalHeadroom * 0.30;
+        const bufferZone = (totalHeadroom - usableHeadroom) / 2;
 
-    // Calculate total vertical headroom (extra space above and below)
-    const totalHeadroom = scaledHeight - VIDEO_HEIGHT; // = 1440 - 1080 = 360px
+        // Randomly choose pan direction (left or right)
+        const direction: PanDirection = Math.random() > 0.5 ? "right" : "left";
 
-    // Use 30% of available headroom for visible pan effect
-    // NOTE: Increased from 15% to 30% to make pan more visible
-    const usableHeadroom = totalHeadroom * 0.30; // 30% of 360px = 108px
+        let xStart: number;
+        let xEnd: number;
 
-    // Leave buffer zones at top and bottom (remaining 70% of headroom)
-    const bufferZone = (totalHeadroom - usableHeadroom) / 2; // = (360 - 108) / 2 = 126px
+        if (direction === "right") {
+            xStart = bufferZone;
+            xEnd = bufferZone + usableHeadroom;
+        } else {
+            xStart = bufferZone + usableHeadroom;
+            xEnd = bufferZone;
+        }
 
-    // Randomly choose pan direction (up or down)
-    const direction: PanDirection = Math.random() > 0.5 ? "down" : "up";
-
-    // Calculate start and end Y positions in pixels
-    let yStart: number;
-    let yEnd: number;
-
-    if (direction === "down") {
-        // Pan down: start at top buffer, end at top buffer + usable headroom
-        yStart = bufferZone;
-        yEnd = bufferZone + usableHeadroom;
+        return {
+            enabled: true,
+            direction,
+            yStart: 0,
+            yEnd: 0,
+            xStart: Math.round(xStart),
+            xEnd: Math.round(xEnd),
+        };
     } else {
-        // Pan up: start at top buffer + usable headroom, end at top buffer
-        yStart = bufferZone + usableHeadroom;
-        yEnd = bufferZone;
-    }
+        // HORIZONTAL: Vertical pan (up/down)
+        // Scale image to fit width, then pan vertically
+        const scaledHeight = (IMAGE_HEIGHT * VIDEO_WIDTH) / IMAGE_WIDTH;
+        const totalHeadroom = scaledHeight - VIDEO_HEIGHT;
+        const usableHeadroom = totalHeadroom * 0.30;
+        const bufferZone = (totalHeadroom - usableHeadroom) / 2;
 
-    return {
-        enabled: true,
-        direction,
-        yStart: Math.round(yStart),
-        yEnd: Math.round(yEnd),
-    };
+        // Randomly choose pan direction (up or down)
+        const direction: PanDirection = Math.random() > 0.5 ? "down" : "up";
+
+        let yStart: number;
+        let yEnd: number;
+
+        if (direction === "down") {
+            yStart = bufferZone;
+            yEnd = bufferZone + usableHeadroom;
+        } else {
+            yStart = bufferZone + usableHeadroom;
+            yEnd = bufferZone;
+        }
+
+        return {
+            enabled: true,
+            direction,
+            yStart: Math.round(yStart),
+            yEnd: Math.round(yEnd),
+            xStart: 0,
+            xEnd: 0,
+        };
+    }
 }
 
 /**
  * Create FFmpeg filter complex for image transitions
  * @param images - Sorted array of images with timing
  * @param panEnabled - Whether pan effect is enabled (from style config)
- * @param zoomToFit - Whether to scale images to fill 1920x1080 (only used when panEnabled is false)
+ * @param zoomToFit - Whether to scale images to fill frame (crop edges)
+ * @param orientation - Video orientation (horizontal or vertical)
  * @returns Filter complex string and total duration
  */
 export function createFilterComplex(
     images: DownloadedImage[],
     panEnabled: boolean = true,
-    zoomToFit: boolean = false
+    zoomToFit: boolean = false,
+    orientation: VideoOrientation = "horizontal"
 ): { filterComplex: string; totalDuration: number } {
     const filters: string[] = [];
     let totalDuration = 0;
 
+    const { width: VIDEO_WIDTH, height: VIDEO_HEIGHT } = getVideoDimensions(orientation);
     const imagesLength = images.length;
 
     // Process each image with optional pan effect
@@ -92,65 +152,43 @@ export function createFilterComplex(
         const image = images[i];
         if (!image) continue;
 
-        const duration = (image.end - image.start) / 1000; // Convert ms to seconds
+        const duration = (image.end - image.start) / 1000;
         totalDuration += duration;
 
-        // Calculate pan parameters for this image
-        const panParams = calculatePanParams(duration, panEnabled);
+        const panParams = calculatePanParams(duration, panEnabled, orientation);
 
         if (panParams.enabled) {
-            // Apply pan effect using scale + crop (NO ZOOMPAN!)
-            //
-            // Why not zoompan?
-            // - zoompan is designed for zoom effects, not simple panning
-            // - It has complex frame timing issues with -loop 1
-            // - For vertical pan only, we just need: scale → crop with animated Y position
-            //
-            // Filter chain:
-            // 1. scale=1920:-1 → Scale to 1920px width, maintain aspect ratio (creates 1920×1440 for 4:3 images)
-            // 2. fps=30 → Set frame rate to 30fps BEFORE crop (ensures proper frame generation)
-            // 3. crop → Crop to 1920×1080 with animated Y position (this creates the pan effect)
-            // 4. setsar=1 → Set sample aspect ratio to 1:1
-            // 5. format=yuv420p → Convert to YUV420P color format
-
             const fps = 30;
             const totalFrames = Math.round(duration * fps);
 
-            // Animated Y position for crop filter
-            //
-            // The crop filter's y parameter can use expressions with 'n' (frame number)
-            // Formula: yStart + (yEnd - yStart) * (n / totalFrames)
-            //
-            // 'n' starts at 0 and increments by 1 for each frame
-            // We clamp it to totalFrames to prevent overshooting
-            const yExpression = `if(lte(n,${totalFrames}),${panParams.yStart}+(${panParams.yEnd}-${panParams.yStart})*n/${totalFrames},${panParams.yEnd})`;
+            if (orientation === "vertical") {
+                // VERTICAL: Scale to fit height, horizontal pan
+                const xExpression = `if(lte(n,${totalFrames}),${panParams.xStart}+(${panParams.xEnd}-${panParams.xStart})*n/${totalFrames},${panParams.xEnd})`;
 
-            // Crop filter parameters:
-            // - w=1920: Output width (crop to 1920px)
-            // - h=1080: Output height (crop to 1080px)
-            // - x=0: Horizontal position (no horizontal pan, start at left edge)
-            // - y=...: Vertical position (animated from yStart to yEnd)
-            //
-            // This crops a 1920×1080 window from the 1920×1440 scaled image,
-            // with the Y position animating from yStart to yEnd over totalFrames frames
-            filters.push(
-                `[${i}:v]scale=1920:-1,fps=${fps},crop=w=1920:h=1080:x=0:y='${yExpression}',setsar=1,format=yuv420p[v${i}]`
-            );
+                filters.push(
+                    `[${i}:v]scale=-1:${VIDEO_HEIGHT},fps=${fps},crop=w=${VIDEO_WIDTH}:h=${VIDEO_HEIGHT}:x='${xExpression}':y=0,setsar=1,format=yuv420p[v${i}]`
+                );
 
-            logger.debug("Video", `Image ${i + 1}: Pan ${panParams.direction} (${panParams.yStart}px → ${panParams.yEnd}px) over ${duration.toFixed(2)}s (${totalFrames} frames)`);
+                logger.debug("Video", `Image ${i + 1}: Pan ${panParams.direction} (X: ${panParams.xStart}px → ${panParams.xEnd}px) [shorts]`);
+            } else {
+                // HORIZONTAL: Scale to fit width, vertical pan
+                const yExpression = `if(lte(n,${totalFrames}),${panParams.yStart}+(${panParams.yEnd}-${panParams.yStart})*n/${totalFrames},${panParams.yEnd})`;
+
+                filters.push(
+                    `[${i}:v]scale=${VIDEO_WIDTH}:-1,fps=${fps},crop=w=${VIDEO_WIDTH}:h=${VIDEO_HEIGHT}:x=0:y='${yExpression}',setsar=1,format=yuv420p[v${i}]`
+                );
+
+                logger.debug("Video", `Image ${i + 1}: Pan ${panParams.direction} (Y: ${panParams.yStart}px → ${panParams.yEnd}px)`);
+            }
         } else {
             // No pan effect - either zoom to fit (crop) or fit with padding
             if (zoomToFit) {
-                // Scale to fill 1920x1080 (center crop, no black bars)
-                // scale=1920:1080:force_original_aspect_ratio=increase → scales to fill
-                // crop=1920:1080 → crops from center to exact dimensions
                 filters.push(
-                    `[${i}:v]scale=1920:1080:force_original_aspect_ratio=increase,crop=1920:1080,setsar=1,fps=30,format=yuv420p[v${i}]`
+                    `[${i}:v]scale=${VIDEO_WIDTH}:${VIDEO_HEIGHT}:force_original_aspect_ratio=increase,crop=${VIDEO_WIDTH}:${VIDEO_HEIGHT},setsar=1,fps=30,format=yuv420p[v${i}]`
                 );
             } else {
-                // Fit within 1920x1080 with black padding (letterbox/pillarbox)
                 filters.push(
-                    `[${i}:v]scale=1920:1080:force_original_aspect_ratio=decrease,pad=1920:1080:(ow-iw)/2:(oh-ih)/2,setsar=1,fps=30,format=yuv420p[v${i}]`
+                    `[${i}:v]scale=${VIDEO_WIDTH}:${VIDEO_HEIGHT}:force_original_aspect_ratio=decrease,pad=${VIDEO_WIDTH}:${VIDEO_HEIGHT}:(ow-iw)/2:(oh-ih)/2,setsar=1,fps=30,format=yuv420p[v${i}]`
                 );
             }
         }

--- a/test-workflow.ts
+++ b/test-workflow.ts
@@ -1,44 +1,14 @@
 /**
  * Test workflow script for local development
  * Runs the complete YouTube automation workflow without Telegram bot
- * Supports caching to avoid wasting AssemblyAI credits
+ * Uses SQLite cache to avoid wasting API credits
  *
  * Usage:
  *   bun test-workflow.ts <audio-file-path>
  *   bun test-workflow.ts  (uses first file in tmp/audio/)
  */
 
-/**
- * ASSEMBLYAI TRANSCRIPT CACHE
- *
- * To avoid wasting credits by re-transcribing the same audio file during testing:
- *
- * Priority order (checked in this order):
- * 1. TRANSCRIPT_ID - If set, fetches existing transcript directly (no upload, no transcription)
- * 2. UPLOAD_URL - If set, skips upload but requests new transcription (uses 1 credit)
- * 3. Neither set - Uploads audio and requests transcription (uses 1 credit)
- *
- * Usage:
- * 1. First run (or when testing new audio file):
- *    - Leave both empty: const TRANSCRIPT_ID = ""; const UPLOAD_URL = "";
- *    - The workflow will upload and transcribe, then log both values
- *
- * 2. Subsequent runs with same audio file (BEST - saves credits):
- *    - Copy the transcript ID: const TRANSCRIPT_ID = "abc123...";
- *    - This fetches the existing transcript without using any credits
- *
- * 3. If you need to re-transcribe with different settings:
- *    - Use upload URL only: const UPLOAD_URL = "https://cdn.assemblyai.com/upload/...";
- *    - This skips upload but creates new transcription (uses 1 credit)
- *
- * Examples:
- *   const TRANSCRIPT_ID = "abc123def456";  // Best option - no credits used
- *   const UPLOAD_URL = "https://cdn.assemblyai.com/upload/a20e52fb-4a09-4d2f-aafe-e65edda37cac";
- */
-const TRANSCRIPT_ID: string = "1ecad84a-dc21-46dc-8afa-3a93b3ef484e";
-const UPLOAD_URL: string = "";
-
-import { requestTranscription, pollForCompletion, uploadAudio, getTranscript } from "./src/services/assemblyai.ts";
+import { transcribeAudio } from "./src/services/assemblyai.ts";
 import { processTranscript, validateTranscriptData } from "./src/services/transcript.ts";
 import { generateImageQueries, validateImageQueries } from "./src/services/llm.ts";
 import { downloadImagesForQueries, validateDownloadedImages } from "./src/services/images.ts";
@@ -46,9 +16,19 @@ import { generateVideo, validateVideoInputs } from "./src/services/video.ts";
 import { uploadVideoToMinIO } from "./src/services/minio.ts";
 import { TMP_AUDIO_DIR, MINIO_ENABLED } from "./src/constants.ts";
 import { getDefaultStyle, resolveStyle } from "./src/styles/index.ts";
+import {
+  hashAudioFile,
+  updateCache,
+  getCachedTranscript,
+  getCachedSegments,
+  getCachedImageQueries,
+  getCachedImages,
+  initDatabase,
+} from "./src/services/cache.ts";
+import type { AssemblyAIWord, TranscriptSegment, ImageSearchQuery, DownloadedImage } from "./src/types.ts";
 import * as logger from "./src/logger.ts";
 import { readdir } from "node:fs/promises";
-import { join } from "node:path";
+import { join, basename } from "node:path";
 import { existsSync } from "node:fs";
 import path from "node:path";
 
@@ -91,142 +71,185 @@ async function getAudioFilePath(): Promise<string> {
     throw new Error(`No audio files found in ${TMP_AUDIO_DIR}. Please add an audio file to test.`);
   }
 
-  const audioFile = audioFiles[0]!; // Safe because we checked length > 0
+  const audioFile = audioFiles[0]!;
   const fullPath = join(TMP_AUDIO_DIR, audioFile);
   logger.log("Test", `Found audio file: ${audioFile}`);
   return fullPath;
-
 }
 
 /**
- * Run the complete workflow
+ * Run the complete workflow with SQLite caching
  */
 async function runTestWorkflow(): Promise<void> {
   const startTime = Date.now();
 
   logger.log("Test", "=".repeat(60));
-  logger.log("Test", "🧪 Starting Test Workflow");
+  logger.log("Test", "🧪 Starting Test Workflow (with SQLite Cache)");
   logger.log("Test", "=".repeat(60));
 
   try {
-    let audioFilePath: string;
-    let transcript;
-    let outputFileName = "output_video";
+    // Initialize cache database
+    initDatabase();
+    logger.log("Test", "📦 SQLite cache initialized");
 
-    // Step 1: Determine audio source and get transcript
-    logger.step("Test", "Step 1: Determining audio source");
+    // Step 1: Get audio file path
+    logger.step("Test", "Step 1: Getting audio file");
+    const audioFilePath = await getAudioFilePath();
+    const outputFileName = path.parse(audioFilePath).name;
+    logger.success("Test", `Audio file: ${audioFilePath}`);
 
-    // Priority 1: Check if we have a cached transcript ID (best - no credits used)
-    if (TRANSCRIPT_ID && TRANSCRIPT_ID.trim() !== "") {
-      logger.log("Test", "🎯 Using cached transcript ID (fetching existing transcript - no credits used)");
-      logger.debug("Test", `Transcript ID: ${TRANSCRIPT_ID}`);
+    // Hash the audio file for cache lookup
+    const audioHash = await hashAudioFile(audioFilePath);
+    logger.log("Test", `Audio hash: ${audioHash.substring(0, 12)}...`);
 
-      // Fetch existing transcript directly
-      transcript = await getTranscript(TRANSCRIPT_ID);
-      logger.success("Test", "✅ Transcript fetched successfully!");
-      logger.log("Test", `📊 Status: ${transcript.status}`);
+    // Initialize cache entry
+    updateCache(audioHash, {
+      audio_filename: basename(audioFilePath),
+      audio_path: audioFilePath,
+    });
 
-      // Use local audio file (AssemblyAI CDN URLs expire, so we need local copy)
-      audioFilePath = await getAudioFilePath();
-      logger.log("Test", `🔗 Using local audio file: ${audioFilePath}`);
-      outputFileName = `video_${TRANSCRIPT_ID}`;
-
-      // Priority 2: Check if we have a cached upload URL (skips upload, uses 1 credit)
-    } else if (UPLOAD_URL && UPLOAD_URL.trim() !== "") {
-      logger.log("Test", "📦 Using cached upload URL (skipping upload, requesting transcription - uses 1 credit)");
-      logger.debug("Test", `Upload URL: ${UPLOAD_URL}`);
-
-      audioFilePath = UPLOAD_URL;
-      outputFileName = `video_upload_${Date.now()}`;
-
-      // Skip upload, use cached URL directly for transcription
-      const transcriptResponse = await requestTranscription(UPLOAD_URL);
-      logger.log("Test", "💡 TIP: To avoid using credits in future runs, copy this transcript ID:");
-      logger.log("Test", `📋 TRANSCRIPT_ID = "${transcriptResponse.id}";`);
-      logger.log("Test", "");
-
-      // Poll for completion
-      if (transcriptResponse.status === "completed") {
-        logger.success("Test", "Transcription already completed");
-        transcript = transcriptResponse;
-      } else {
-        transcript = await pollForCompletion(transcriptResponse.id);
-      }
-
-      // Priority 3: No cache - find local file, upload and transcribe (uses 1 credit)
-    } else {
-      logger.log("Test", "📂 No cache found - searching for local audio file");
-
-      // Find local file
-      audioFilePath = await getAudioFilePath();
-      logger.success("Test", `Local audio file found: ${audioFilePath}`);
-      outputFileName = path.parse(audioFilePath).name;
-
-      logger.log("Test", "📤 Uploading audio and requesting transcription (uses 1 credit)");
-
-      // Upload the audio file
-      const uploadUrl = await uploadAudio(audioFilePath);
-      logger.success("Test", "✅ Audio uploaded successfully!");
-
-      // Request transcription
-      const transcriptResponse = await requestTranscription(uploadUrl);
-
-      logger.log("Test", "");
-      logger.log("Test", "💡 TIP: To save credits in future test runs, copy these values:");
-      logger.log("Test", `📋 TRANSCRIPT_ID = "${transcriptResponse.id}";  // Best option - no credits used`);
-      logger.log("Test", `📋 UPLOAD_URL = "${uploadUrl}";  // Alternative - skips upload but uses 1 credit`);
-      logger.log("Test", "");
-
-      // Poll for completion
-      if (transcriptResponse.status === "completed") {
-        logger.success("Test", "Transcription already completed");
-        transcript = transcriptResponse;
-      } else {
-        transcript = await pollForCompletion(transcriptResponse.id);
-      }
-    }
-
-    if (!transcript || !transcript.words || transcript.words.length === 0) {
-      throw new Error("Transcription returned no words");
-    }
-
-    logger.success("Test", `Transcription completed: ${transcript.words.length} words`);
-    logger.debug("Test", `Transcript text: ${transcript.text?.substring(0, 100)}...`);
-
-    // Step 3: Validate and process transcript
-    logger.step("Test", "Step 3: Processing transcript into segments");
-    validateTranscriptData(transcript.words);
     // Use default style for testing
     const style = resolveStyle(getDefaultStyle(), {});
-    const { segments, formattedTranscript } = processTranscript(transcript.words, transcript.audio_duration, style);
-    logger.success("Test", `Created ${segments.length} segments (style: ${style.name})`);
+    logger.log("Test", `Using style: ${style.name}`);
 
-    // Step 4: Generate image search queries with LLM
+    // =============================================================
+    // Step 2: Transcription (check cache first)
+    // =============================================================
+    logger.step("Test", "Step 2: Transcription");
+
+    let transcriptWords: AssemblyAIWord[];
+    let audioDuration: number | null;
+
+    const cachedTranscript = getCachedTranscript(audioHash);
+
+    if (cachedTranscript) {
+      logger.log("Test", "📦 Using cached transcript (no API call)");
+      transcriptWords = cachedTranscript.words;
+      audioDuration = cachedTranscript.audioDuration;
+      logger.success("Test", `Loaded ${transcriptWords.length} words from cache`);
+    } else {
+      logger.log("Test", "🔄 No cache - calling AssemblyAI...");
+      const transcript = await transcribeAudio(audioFilePath);
+      transcriptWords = transcript.words;
+      audioDuration = transcript.audio_duration;
+
+      // Save to cache
+      updateCache(audioHash, {
+        transcript_id: transcript.id,
+        transcript_words: JSON.stringify(transcript.words),
+        audio_duration: transcript.audio_duration ?? undefined,
+      });
+
+      logger.success("Test", `Transcribed ${transcriptWords.length} words and cached`);
+    }
+
+    validateTranscriptData(transcriptWords);
+
+    // =============================================================
+    // Step 3: Segmentation (check cache first, style-specific)
+    // =============================================================
+    logger.step("Test", "Step 3: Segmentation");
+
+    let segments: TranscriptSegment[];
+    let formattedTranscript: string;
+
+    const cachedSegments = getCachedSegments(audioHash, style.id);
+
+    if (cachedSegments) {
+      logger.log("Test", "📦 Using cached segments (same style)");
+      segments = cachedSegments.segments;
+      formattedTranscript = cachedSegments.formattedTranscript;
+      logger.success("Test", `Loaded ${segments.length} segments from cache`);
+    } else {
+      logger.log("Test", "🔄 Processing transcript into segments...");
+      const result = processTranscript(transcriptWords, audioDuration, style);
+      segments = result.segments;
+      formattedTranscript = result.formattedTranscript;
+
+      // Save to cache
+      updateCache(audioHash, {
+        segments: JSON.stringify(segments),
+        formatted_transcript: formattedTranscript,
+        style_id: style.id,
+      });
+
+      logger.success("Test", `Created ${segments.length} segments and cached`);
+    }
+
+    // =============================================================
+    // Step 4: LLM Image Queries (check cache first, style-specific)
+    // =============================================================
     logger.step("Test", "Step 4: Generating image queries");
-    const imageQueries = await generateImageQueries(formattedTranscript, style);
-    validateImageQueries(imageQueries);
-    logger.success("Test", `Generated ${imageQueries.length} image queries`);
 
-    // Validate that we have exactly one query per segment
+    let imageQueries: ImageSearchQuery[];
+
+    const cachedQueries = getCachedImageQueries(audioHash, style.id);
+
+    if (cachedQueries) {
+      logger.log("Test", "📦 Using cached image queries (no LLM call)");
+      imageQueries = cachedQueries;
+      logger.success("Test", `Loaded ${imageQueries.length} queries from cache`);
+    } else {
+      logger.log("Test", "🔄 Calling LLM to generate queries...");
+      imageQueries = await generateImageQueries(formattedTranscript, style);
+      validateImageQueries(imageQueries);
+
+      // Save to cache
+      updateCache(audioHash, {
+        image_queries: JSON.stringify(imageQueries),
+      });
+
+      logger.success("Test", `Generated ${imageQueries.length} queries and cached`);
+    }
+
+    // Validate query count matches segment count
     if (imageQueries.length !== segments.length) {
       throw new Error(
         `Mismatch: Expected ${segments.length} queries (one per segment), but got ${imageQueries.length} queries from LLM`
       );
     }
 
-    // Step 5: Search and download images
+    // =============================================================
+    // Step 5: Download Images (check cache first)
+    // =============================================================
     logger.step("Test", "Step 5: Downloading images");
-    const downloadedImages = await downloadImagesForQueries(imageQueries, style);
-    validateDownloadedImages(downloadedImages);
-    logger.success("Test", `Downloaded ${downloadedImages.length} images`);
 
-    // Step 6: Generate video with FFmpeg
-    logger.step("Test", "Step 6: Generating video");
+    let downloadedImages: DownloadedImage[];
+
+    const cachedImages = getCachedImages(audioHash);
+
+    if (cachedImages && cachedImages.length === imageQueries.length) {
+      logger.log("Test", "📦 Using cached images (all files verified)");
+      downloadedImages = cachedImages;
+      logger.success("Test", `Loaded ${downloadedImages.length} images from cache`);
+    } else {
+      logger.log("Test", "🔄 Downloading images...");
+      downloadedImages = await downloadImagesForQueries(imageQueries, style);
+      validateDownloadedImages(downloadedImages);
+
+      // Save to cache
+      updateCache(audioHash, {
+        downloaded_images: JSON.stringify(downloadedImages),
+      });
+
+      logger.success("Test", `Downloaded ${downloadedImages.length} images and cached`);
+    }
+
+    // =============================================================
+    // Step 6: Generate Video (always regenerate)
+    // =============================================================
+    logger.step("Test", "Step 6: Generating video (always fresh)");
     validateVideoInputs(downloadedImages, audioFilePath);
 
-    const videoResult = await generateVideo(downloadedImages, audioFilePath, transcript.words, segments, outputFileName, style);
-    logger.success("Test", `Video generated successfully!`);
-    logger.log("Test", `Video saved at: ${videoResult.videoPath}`);
+    const videoResult = await generateVideo(
+      downloadedImages,
+      audioFilePath,
+      transcriptWords,
+      segments,
+      outputFileName,
+      style
+    );
+    logger.success("Test", `Video generated: ${videoResult.videoPath}`);
 
     // Step 7: Upload to MinIO (if enabled)
     if (MINIO_ENABLED) {
@@ -234,9 +257,7 @@ async function runTestWorkflow(): Promise<void> {
       const minioResult = await uploadVideoToMinIO(videoResult.videoPath);
 
       if (minioResult.success) {
-        logger.success("Test", `Video uploaded to MinIO: ${minioResult.url}`);
-        logger.log("Test", `Bucket: ${minioResult.bucket}`);
-        logger.log("Test", `Object key: ${minioResult.objectKey}`);
+        logger.success("Test", `Uploaded to MinIO: ${minioResult.url}`);
       } else {
         logger.warn("Test", `MinIO upload failed: ${minioResult.error}`);
       }
@@ -247,13 +268,15 @@ async function runTestWorkflow(): Promise<void> {
     const totalTime = ((endTime - startTime) / 1000).toFixed(2);
 
     logger.log("Test", "=".repeat(60));
-    logger.log("Test", "✅ Test Workflow Completed Successfully!");
+    logger.log("Test", "✅ Test Workflow Completed!");
     logger.log("Test", "=".repeat(60));
     logger.log("Test", `📊 Summary:`);
-    logger.log("Test", `   • Audio source: ${audioFilePath.startsWith('http') ? 'Remote URL' : 'Local File'}`);
-    logger.log("Test", `   • Video duration: ${videoResult.duration.toFixed(2)} seconds`);
-    logger.log("Test", `   • Video path: ${videoResult.videoPath}`);
-    logger.log("Test", `   • Total processing time: ${totalTime} seconds`);
+    logger.log("Test", `   • Audio: ${basename(audioFilePath)}`);
+    logger.log("Test", `   • Style: ${style.name}`);
+    logger.log("Test", `   • Segments: ${segments.length}`);
+    logger.log("Test", `   • Duration: ${videoResult.duration.toFixed(2)}s`);
+    logger.log("Test", `   • Video: ${videoResult.videoPath}`);
+    logger.log("Test", `   • Time: ${totalTime}s`);
     logger.log("Test", "=".repeat(60));
 
   } catch (error) {


### PR DESCRIPTION
SQLite Cache System:
- Add cache.ts service using Bun's built-in SQLite for workflow caching
- Cache transcription, segmentation, LLM queries, and images
- Skip API calls when cached data exists (same audio hash)
- Style-specific caching for segments and image queries
- Integrate cache cleanup with /cleanup command
- Update test-workflow.ts to use SQLite cache

Vertical Shorts Support (--short flag):
- Add VideoOrientation type (horizontal/vertical)
- Parse --short flag in style options
- Vertical: 1080x1920 (9:16), horizontal pan (left/right)
- Override font size (62px), words per caption (2-4), zoomToFit
- Update ASS captions with dynamic resolution and margins
- Update SETUP.md with --short documentation

Stability Improvements:
- Handle 409 Conflict errors gracefully (another bot instance)
- Wait for active jobs to complete before shutdown
- Add hasActiveJob() and waitForCurrentJob() to queue service

Performance:
- Skip pan effect for segments under 3 seconds (too jarring)
- Add video dimension constants for both orientations